### PR TITLE
D2l support for py2.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.pyc
+.tox
+build
+dist
+*.egg-info*

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@
 History
 -------
 
+1.2.0 (2016-02-25)
+++++++++++++++++++
+* Update package to use the `python-future <http://python-future.org/index.html>`
+  library to add Python 2 compatibility.
+
+
 1.1.1 (2014-05-26)
 ++++++++++++++++++
 * Added some validation around user context method accepting API routes to

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 -*- coding: utf-8 -*-
 D2LValence client library package.
 
-    Copyright (c) 2012-2014 Desire2Learn Incorporated.
+    Copyright (c) 2012-2016 Desire2Learn Incorporated.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not
 use this file except in compliance with the License. You may obtain a copy of

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ You can find the source for our Python client library SDK in two locations:
 first ensure you have a working Python development environment:
 
 * Python 3 (the reference environment uses Python 3.5), or Python 2.7 (via the
-  use of the future library.
+  use of the future library).
 
 * The `Requests Python package <http://docs.python-requests.org/en/latest/index.html>`_
   gets included in our :py:mod:`auth <d2lvalence.auth>` module so that you can use a

--- a/README.rst
+++ b/README.rst
@@ -25,19 +25,16 @@ You can find the source for our Python client library SDK in two locations:
 **Dependencies**. In order to use the Python client library SDK, you'll need to
 first ensure you have a working Python development environment:
 
-* Python 3 (the reference environment uses Python 3.3).
+* Python 3 (the reference environment uses Python 3.5), or Python 2.7 (via the
+  use of the future library.
 
 * The `Requests Python package <http://docs.python-requests.org/en/latest/index.html>`_
-  gets in our our :py:mod:`auth <d2lvalence.auth>` module so that you can use a
+  gets included in our :py:mod:`auth <d2lvalence.auth>` module so that you can use a
   calling user context object as an authentication helper for Requests.
+
+* The `python-future <http://python-future.org/index.html>`_ library gets used
+  to provide Python 2.7 compatibility.
 
 * The `Bottle Python package <http://bottlepy.org/docs/dev/>`_ if you want to
   use the samples available in conjunction with this client library (not a
   dependency for the client library itself).
-
-
-Where'd d2lvalence.data and d2lvalence.service go?
-==================================================
-The data and service modules have been decoupled from this package going
-forward. Continued support for them may appear in a separate `d2lvalence-util`
-package.

--- a/d2lvalence/__init__.py
+++ b/d2lvalence/__init__.py
@@ -8,10 +8,14 @@
 :see: http://www.desire2learn.com/r/valencehome for more information about the
       Valence project.
 """
+from __future__ import (absolute_import, division, print_function, unicode_literals)
+from future.standard_library import install_aliases
+install_aliases()
+from builtins import *
 
 __title__ = 'd2lvalence'
-__version__ = '1.1.1'
-__build__ = 0x010101
+__version__ = '1.2.0'
+__build__ = 0x010200
 __author__ = 'Desire2Learn Extensibility'
 __license__ = 'Apache 2.0'
-__copyright__ = 'Copyright 2012-2014 Desire2Learn Incorporated.'
+__copyright__ = 'Copyright 2012-2016 Desire2Learn Incorporated.'

--- a/d2lvalence/auth.py
+++ b/d2lvalence/auth.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # D2LValence package, auth module.
 #
-# Copyright (c) 2012-2014 Desire2Learn Inc.
+# Copyright (c) 2012-2016 Desire2Learn Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of

--- a/d2lvalence/auth.py
+++ b/d2lvalence/auth.py
@@ -20,6 +20,11 @@
 :synopsis: Provides auth assistance for Desire2Learn's Valence API client
            applications.
 """
+from __future__ import (absolute_import, division, print_function, unicode_literals)
+from future.standard_library import install_aliases
+install_aliases()
+from builtins import *
+
 
 ### Authentication ###
 # For use with D2LSigner

--- a/d2lvalence/auth.py
+++ b/d2lvalence/auth.py
@@ -66,6 +66,17 @@ def fashion_user_context(app_id='',
     return ac.create_user_context(
         d2l_user_context_props_dict=d2l_user_context_props_dict)
 
+# internal helper function that helps cope with newstr normalizing for
+# use of future with urllib.parse.unsplit()
+def _stringify_components(l):
+    l2 = []
+    for i in l:
+        if not isinstance(i,str):
+            l2.append(str(i))
+        else:
+            l2.append(i)
+    return tuple(l2)
+
 
 # classes
 class D2LSigner(object):
@@ -216,8 +227,10 @@ class D2LAppContext(object):
             scheme = self.SCHEME_U
         netloc = host
         path = self.AUTH_API
+
         query = urllib.parse.urlencode(parms_dict, doseq=True)
-        result = urllib.parse.urlunsplit((scheme, netloc, path, query, fragment))
+        components = _stringify_components((scheme, netloc, path, query, fragment))
+        result = urllib.parse.urlunsplit(components)
 
         return result
 
@@ -438,8 +451,9 @@ class D2LUserContext(AuthBase):
 
         qparms_dict.update(self._build_tokens_for_path(path, method=method))
         query = urllib.parse.urlencode(qparms_dict, doseq=True)
+        components = _stringify_components((scheme, netloc, path, query, fragment))
 
-        return urllib.parse.urlunsplit((scheme, netloc, path, query, fragment))
+        return urllib.parse.urlunsplit(components)
     
     def create_authenticated_url(self,
                                  api_route='/d2l/api/versions/',
@@ -467,8 +481,9 @@ class D2LUserContext(AuthBase):
                                              path,
                                              method=method),
                                        doseq=True)
+        components = _stringify_components((scheme, netloc, path, query, fragment))
 
-        return urllib.parse.urlunsplit((scheme, netloc, path, query, fragment))
+        return urllib.parse.urlunsplit(components)
 
     # Currently, this function does very little, and is present mostly for
     # symmetry with the other Valence client library packages.

--- a/setup.py
+++ b/setup.py
@@ -7,52 +7,64 @@ Form of this file borrowed from Kenneth Reitz' requests package
 """
 
 import os
+import re
 import sys
+from codecs import open
 
 try:
-    from setuptools import setup
-    setup
+    from setuptools import setup, find_packages
 except ImportError:
-    from distutils.core import setup
-
-import d2lvalence
+    from distutils.core import setup, find_packages
 
 if sys.argv[-1] == 'publish':
     os.system('python setup.py sdist upload')
     sys.exit
 
-packages = ['d2lvalence', ]
+_packages = ['d2lvalence', ]
+_package_data = ['LICENSE', ]
+_requires = ['future >= 0.15.2', 'requests >= 1.2.0', ]
 
-# We depend on Kenneth Reitz' requests package to handle the actual HTTP traffic
-requires = ['requests >= 1.2.0', ]
+def _get_val_from_mod(k):
+    with open('d2lvalence/__init__.py', 'r') as fd:
+        return re.search(r'^__{0}__\s*=\s*[\'"]([^\'"]*)[\'"]'.format(k),
+                         fd.read(),
+                         re.MULTILINE).group(1)
+
+_author = _get_val_from_mod('author')
+_license = _get_val_from_mod('license')
+_title = _get_val_from_mod('title')
+_version = _get_val_from_mod('version')
+
+with open('README.rst', 'r', 'utf-8') as f:
+          _readme = f.read()
 
 setup(
-    name='D2LValence',
-    version=d2lvalence.__version__,
-    description='D2LValence client library for Python.',
-    long_description=open('README.rst').read() + '\n\n' +
-                     open('HISTORY.rst').read(),
-    author='Desire2Learn Inc.',
-    author_email='Valence@Desire2Learn.com',
-    url='http://www.desire2learn.com/r/valencehome',
-    packages=packages,
-    package_data={'': ['LICENSE', ] },
-    include_package_data=True,
-    install_requires=[
-        'requests >= 1.2.0',
-        ],
-    license=open('LICENSE').read(),
+    name = _title,
+    version = _version,
+    description ='D2LValence client library for Python.',
+    long_description = _readme + '\n\n',
+    author = _author,
+    author_email ='Valence@Desire2Learn.com',
+    url = 'http://www.desire2learn.com/r/valencehome',
+    packages = _packages,
+    package_data = {'': _package_data },
+    include_package_data = True,
+    install_requires = _requires,
+    license = _license,
     classifiers=(
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'Natural Language :: English',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.0',
         'Programming Language :: Python :: 3.1',
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4'
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         ),
     )


### PR DESCRIPTION
Provide support for py2.7 via the use of the future library (http://python-future.org/index.html).
